### PR TITLE
baylibre_ssh_project: migrate to baylibre instance

### DIFF
--- a/baylibre_ssh_project.xml
+++ b/baylibre_ssh_project.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <remote  name="gitlab" fetch="ssh://git@gitlab.com" />
+    <remote  name="gitlab" fetch="ssh://git@gitlab.baylibre.com" />
     <default revision="main" remote="gitlab" />
 
-    <project path="project-jobs/rita" name="baylibre-ci/concourse-ci/projects-jobs/rita.git" />
+    <project path="project-jobs/rita" name="baylibre/ci/concourse/pipelines/mediatek.git" />
 </manifest>


### PR DESCRIPTION
The public gitlab.com instance has access restrictions. Migrate the manifest to use gitlab.baylibre.com.