### PR TITLE
tests: Update demo-manifest url to https://github.com/baylibre/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # demo-manifests
-A collection of Google repo manifests used for [concourse-repo](https://github.com/makohoek/repo-resource) testing
+A collection of Google repo manifests used for [concourse-repo](https://github.com/baylibre/repo-resource) testing


### PR DESCRIPTION
The demo manifest has been migrated to the baylibre organisation from https://github.com/makohoek/demo-manifests.git to https://github.com/baylibre/demo-manifests.git

Use the new URL everywhere.