### PR TITLE
tests: Update demo-manifest url to https://github.com/baylibre/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # demo-manifests
-A collection of Google repo manifests used for [concourse-repo](https://github.com/makohoek/repo-resource) testing
+A collection of Google repo manifests used for [concourse-repo](https://github.com/baylibre/repo-resource) testing

--- a/branch_matching.xml
+++ b/branch_matching.xml
@@ -2,5 +2,5 @@
 <manifest>
     <remote name="github" fetch="https://github.com/" />
 
-    <project path="rev" name="makohoek/demo-manifests.git" remote="github" revision="rev" />
+    <project path="rev" name="baylibre/demo-manifests.git" remote="github" revision="rev" />
 </manifest>

--- a/one_project_multi_path.xml
+++ b/one_project_multi_path.xml
@@ -2,6 +2,6 @@
 <manifest>
     <remote name="github" fetch="https://github.com/" />
 
-    <project path="rev-1" name="makohoek/demo-manifests.git" remote="github" revision="fixed-rev-1" />
-    <project path="rev-2" name="makohoek/demo-manifests.git" remote="github" revision="fixed-rev-2" />
+    <project path="rev-1" name="baylibre/demo-manifests.git" remote="github" revision="fixed-rev-1" />
+    <project path="rev-2" name="baylibre/demo-manifests.git" remote="github" revision="fixed-rev-2" />
 </manifest>


### PR DESCRIPTION
The demo manifest has been migrated to the baylibre organisation from https://github.com/makohoek/demo-manifests.git to https://github.com/baylibre/demo-manifests.git

Use the new URL everywhere.